### PR TITLE
Before/After middleware can be set via yaml/xml and supported HTTP methods extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ $routingServiceProvider = new RoutingServiceProvider();
 
 $routes = array(
     'foo' => array(
-        //'name' => 'foo', --> you can omit the routeName if a key is set
+        //'name' => 'foo', --> you can omit the route name if a key is set
         'pattern' => '/foo',
         'controller' => 'Foo\Controller\FooController::fooAction',
         'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
     ),
     'baz' => array(
-        //'name' => 'baz', --> you can omit the routeName if a key is set
+        //'name' => 'baz', --> you can omit the route name if a key is set
         'pattern' => '/baz',
         'controller' => 'Baz\Controller\BazController::bazAction',
         'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
@@ -155,7 +155,7 @@ $routingServiceProvider = new RoutingServiceProvider();
 
 $routes = array(
     'foo' => array(
-        //'routeName' => 'foo', --> you can omit the routeName if a key is set
+        //'name' => 'foo', --> you can omit the route name if a key is set
         'pattern' => '/foo',
         'controller' => 'Foo\Controller\FooController::fooAction',
         'method' => array('get'),
@@ -165,17 +165,39 @@ $routes = array(
 );
 $routingServiceProvider->addRoutes($app, $route);
 ```
-### Registering providers with configuration
 
-For this example the [ConfigServiceProvider](https://github.com/igorw/ConfigServiceProvider) is used to read the yml file. The RoutingServiceProvider picks the stored configuration through the node `config.routing` as in `$app['config.routing']` by default. If you want to set a different key, add it as parameter when instantiating the RoutingServiceProvider
-***Note: The key of the array will also be used as the routeName, so you can omit routeName.
+#### Adding a route middleware class via yml
+
+You can add middleware classes via yml-/xml-configuration. Example: 
 
 `routes.yaml`
 
 ```yaml
 config.routes:
     home:
-        routeName: 'home'
+        name: 'home'
+        pattern: /
+        method: [ 'get', 'post' ]
+        controller: 'Foo\Controllers\FooController::getAction'
+        before: 'Foo\Middleware\FooController::before'
+        after: 'Foo\Middleware\FooController::after'
+```
+The methods' interface need to match the Silex specification. Further information about route middleware classses: http://silex.sensiolabs.org/doc/middlewares.html#route-middlewares.
+
+ATTENTION: Unfortunately with this way, you cannot use the ´__invoke´ method described above.
+
+
+### Registering providers with configuration
+
+For this example the [ConfigServiceProvider](https://github.com/igorw/ConfigServiceProvider) is used to read the yml file. The RoutingServiceProvider picks the stored configuration through the node `config.routing` as in `$app['config.routing']` by default. If you want to set a different key, add it as parameter when instantiating the RoutingServiceProvider
+***Note: The key of the array will also be used as the ´route´, so you can omit ´route.
+
+`routes.yaml`
+
+```yaml
+config.routes:
+    home:
+        name: 'home'
         pattern: /
         method: [ 'get', 'post' ]
         controller: 'Foo\Controllers\FooController::getAction'
@@ -230,4 +252,3 @@ $app->register(new RoutingServiceProvider('custom.routing.key'));
 ## Todo
 
 convert, there is no option set this per route at the moment
-before & after middleware still need to be implemented using xml and yml. (if possible)

--- a/src/MJanssen/Provider/RoutingServiceProvider.php
+++ b/src/MJanssen/Provider/RoutingServiceProvider.php
@@ -108,7 +108,7 @@ class RoutingServiceProvider implements ServiceProviderInterface {
      * @param array $methods
      */
     protected function validateMethods(Array $methods) {
-        $availableMethods = array('get', 'put', 'post', 'delete', 'options', 'head');
+        $availableMethods = array('get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'purge', 'options', 'trace', 'connect');
         foreach (array_map('strtolower', $methods) as $method) {
             if (!in_array($method, $availableMethods)) {
                 throw new InvalidArgumentException('Method "' . $method . '" is not valid, only the following methods are allowed: ' . join(', ', $availableMethods));

--- a/tests/MJanssen/Provider/RoutingServiceProviderTest.php
+++ b/tests/MJanssen/Provider/RoutingServiceProviderTest.php
@@ -262,9 +262,10 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testRoutePattern()
     {
         $routeCollection = $this->getValidRoute();
+        /** @var \Silex\Route $route */
         $route = $routeCollection->getIterator()->current();
 
-        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('/foo', $route->getPath());
     }
 
     /**
@@ -386,6 +387,31 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
         $route['before'] = '';
+        $routingServiceProvider->addRoute($app, $route);
+
+    }
+
+    /**
+     *
+     */
+    public function testAddBeforeAfterMiddlewareByString()
+    {
+        $app = new Application();
+        $routingServiceProvider = new RoutingServiceProvider();
+        $route = $this->validRoute;
+
+        $mwClassName = 'FooMiddleware';
+        $mwMethod = 'foo';
+
+        //Create a Middleware-class mock
+        /** @var \PHPUnit_Framework_MockObject_MockObject $fooMiddleware */
+        $fooMiddleware = $this->getMockBuilder('none')
+            ->setMockClassName($mwClassName)
+            ->setMethods(array($mwMethod))
+            ->getMock();
+
+        $route['before'] = [$mwClassName . '::' . $mwMethod];
+
         $routingServiceProvider->addRoute($app, $route);
 
     }


### PR DESCRIPTION
Two commits:

- The first commit adds the possibility to specify a before/after route middleware class
- The second commit adds the missing HTTP-request methods. Now the methods 'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'purge', 'options', 'trace', 'connect' are supported