### PR TITLE
Before/After middleware via yaml/xml, supported HTTP methods extended, improved tests and documentation and added route variable converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ $routingServiceProvider = new RoutingServiceProvider();
 
 $routes = array(
     'foo' => array(
-        //'name' => 'foo', --> you can omit the routeName if a key is set
+        //'name' => 'foo', --> you can omit the route name if a key is set
         'pattern' => '/foo',
         'controller' => 'Foo\Controller\FooController::fooAction',
         'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
     ),
     'baz' => array(
-        //'name' => 'baz', --> you can omit the routeName if a key is set
+        //'name' => 'baz', --> you can omit the route name if a key is set
         'pattern' => '/baz',
         'controller' => 'Baz\Controller\BazController::bazAction',
         'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
@@ -155,7 +155,7 @@ $routingServiceProvider = new RoutingServiceProvider();
 
 $routes = array(
     'foo' => array(
-        //'routeName' => 'foo', --> you can omit the routeName if a key is set
+        //'name' => 'foo', --> you can omit the route name if a key is set
         'pattern' => '/foo',
         'controller' => 'Foo\Controller\FooController::fooAction',
         'method' => array('get'),
@@ -165,17 +165,39 @@ $routes = array(
 );
 $routingServiceProvider->addRoutes($app, $route);
 ```
-### Registering providers with configuration
 
-For this example the [ConfigServiceProvider](https://github.com/igorw/ConfigServiceProvider) is used to read the yml file. The RoutingServiceProvider picks the stored configuration through the node `config.routing` as in `$app['config.routing']` by default. If you want to set a different key, add it as parameter when instantiating the RoutingServiceProvider
-***Note: The key of the array will also be used as the routeName, so you can omit routeName.
+#### Adding a route middleware class via yml
+
+You can add middleware classes via yml-/xml-configuration. Example: 
 
 `routes.yaml`
 
 ```yaml
 config.routes:
     home:
-        routeName: 'home'
+        name: 'home'
+        pattern: /
+        method: [ 'get', 'post' ]
+        controller: 'Foo\Controllers\FooController::getAction'
+        before: 'Foo\Middleware\FooController::before'
+        after: 'Foo\Middleware\FooController::after'
+```
+The methods' interface need to match the Silex specification. Further information about route middleware classses: http://silex.sensiolabs.org/doc/middlewares.html#route-middlewares.
+
+ATTENTION: Unfortunately with this way, you cannot use the ´__invoke´ method described above.
+
+
+### Registering providers with configuration
+
+For this example the [ConfigServiceProvider](https://github.com/igorw/ConfigServiceProvider) is used to read the yml file. The RoutingServiceProvider picks the stored configuration through the node `config.routing` as in `$app['config.routing']` by default. If you want to set a different key, add it as parameter when instantiating the RoutingServiceProvider
+***Note: The key of the array will also be used as the ´route´, so you can omit ´route.
+
+`routes.yaml`
+
+```yaml
+config.routes:
+    home:
+        name: 'home'
         pattern: /
         method: [ 'get', 'post' ]
         controller: 'Foo\Controllers\FooController::getAction'
@@ -230,4 +252,3 @@ $app->register(new RoutingServiceProvider('custom.routing.key'));
 ## Todo
 
 convert, there is no option set this per route at the moment
-before & after middleware still need to be implemented using xml and yml. (if possible)

--- a/README.md
+++ b/README.md
@@ -46,25 +46,41 @@ $routes = array(
 
 Optionally the following parameters can also be added:
 
-* value (array)
+### value (array)
+
+You can add default values for any route variable: http://silex.sensiolabs.org/doc/usage.html#default-values
 
 ``` php
 $value = array('name' => 'value')
 ```
 
-* assert (array)
+### assert (array)
+
+You can add requirements: http://silex.sensiolabs.org/doc/usage.html#requirements
 
 ``` php
 $assert = array('id' => '^[\d]+$')
 ```
 
-* before (array)
+### convert (array)
+
+You can add route variable converters: http://silex.sensiolabs.org/doc/usage.html#route-variable-converters. Before you can use the route variable converter, you need to add it as a service.
+
+``` php
+$after = array('convert' => function() {})
+```
+
+### before (array)
+
+Add a before-middleware: http://silex.sensiolabs.org/doc/middlewares.html#before-middleware
 
 ``` php
 $before = array('before' => function() {})
 ```
 
-* after (array)
+### after (array)
+
+Add an after-middleware: http://silex.sensiolabs.org/doc/middlewares.html#after-middleware
 
 ``` php
 $after = array('after' => function() {})
@@ -251,4 +267,4 @@ $app->register(new RoutingServiceProvider('custom.routing.key'));
 
 ## Todo
 
-convert, there is no option set this per route at the moment
+* convert: route variable converters need to be services. We need a way to add them as a valid callback like `MyNamespace\MyClass::converter` 

--- a/src/MJanssen/Provider/RoutingServiceProvider.php
+++ b/src/MJanssen/Provider/RoutingServiceProvider.php
@@ -108,7 +108,7 @@ class RoutingServiceProvider implements ServiceProviderInterface {
      * @param array $methods
      */
     protected function validateMethods(Array $methods) {
-        $availableMethods = array('get', 'put', 'post', 'delete', 'options', 'head');
+        $availableMethods = array('get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'purge', 'options', 'trace', 'connect');
         foreach (array_map('strtolower', $methods) as $method) {
             if (!in_array($method, $availableMethods)) {
                 throw new InvalidArgumentException('Method "' . $method . '" is not valid, only the following methods are allowed: ' . join(', ', $availableMethods));

--- a/src/MJanssen/Provider/RoutingServiceProvider.php
+++ b/src/MJanssen/Provider/RoutingServiceProvider.php
@@ -92,7 +92,7 @@ class RoutingServiceProvider implements ServiceProviderInterface
                 join('|', array_map('strtoupper', $route['method']))
             );
 
-        $supportedProperties = array('value', 'assert', 'before', 'after');
+        $supportedProperties = array('value', 'assert', 'convert', 'before', 'after');
         foreach ($supportedProperties AS $property) {
             if (isset($route[$property])) {
                 $this->addActions($controller, $route[$property], $property);

--- a/tests/MJanssen/Provider/RoutingServiceProviderTest.php
+++ b/tests/MJanssen/Provider/RoutingServiceProviderTest.php
@@ -2,9 +2,6 @@
 namespace MJanssen\Provider;
 
 use Silex\Application;
-use MJanssen\Provider\RoutingServiceProvider;
-use Silex\ControllerCollection;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
@@ -81,14 +78,14 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * test if multiple routes can be added
-    */
+     */
     public function testAddRoutes()
     {
         $app = new Application();
         $routingServiceProvider = new RoutingServiceProvider();
 
         $routes = array(
-            'foo' =>  array(
+            'foo' => array(
                 'pattern' => '/foo',
                 'controller' => 'MJanssen\Controller\FooController::fooAction',
                 'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
@@ -346,8 +343,12 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
         $route['after'] = array(
-            function() { return 'foo'; },
-            function() { return 'baz'; }
+            function () {
+                return 'foo';
+            },
+            function () {
+                return 'baz';
+            }
 
         );
         $routingServiceProvider->addRoute($app, $route);
@@ -359,8 +360,12 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
         $route['before'] = array(
-            function() { return 'foo'; },
-            function() { return 'baz'; }
+            function () {
+                return 'foo';
+            },
+            function () {
+                return 'baz';
+            }
         );
         $routingServiceProvider->addRoute($app, $route);
 
@@ -391,26 +396,76 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    /**
-     *
-     */
     public function testAddBeforeAfterMiddlewareByString()
+    {
+        $procedureTerminates = false;
+        $app = new Application();
+        $routingServiceProvider = new RoutingServiceProvider();
+        $route = $this->validRoute;
+
+        $middlewareClassName = 'FooMiddleware1';
+        $middlewareMethod = 'foo1';
+
+        //Create a Middleware-class mock
+        /** @var \PHPUnit_Framework_MockObject_MockObject $fooMiddleware */
+        $fooMiddleware = $this->getMockBuilder('none')
+            ->setMockClassName($middlewareClassName)
+            ->setMethods(array($middlewareMethod))
+            ->getMock();
+
+        $route['before'] = [$middlewareClassName . '::' . $middlewareMethod];
+
+        $routingServiceProvider->addRoute($app, $route);
+
+        $procedureTerminates = true;
+        $this->assertTrue($procedureTerminates, 'The procedure did not terminate, therefore the middleware was not added');
+
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddBeforeAfterMiddlewareInvalidArgumentException()
     {
         $app = new Application();
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
 
-        $mwClassName = 'FooMiddleware';
-        $mwMethod = 'foo';
+        $middlewareClassName = 'FooMiddleware2';
+        $middlewareMethod = 'foo2';
 
         //Create a Middleware-class mock
         /** @var \PHPUnit_Framework_MockObject_MockObject $fooMiddleware */
         $fooMiddleware = $this->getMockBuilder('none')
-            ->setMockClassName($mwClassName)
-            ->setMethods(array($mwMethod))
+            ->setMockClassName($middlewareClassName)
+            ->setMethods(array($middlewareMethod))
             ->getMock();
 
-        $route['before'] = [$mwClassName . '::' . $mwMethod];
+        $route['before'] = [$middlewareClassName . ':' . $middlewareMethod]; //no valid callback
+
+        $routingServiceProvider->addRoute($app, $route);
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @group test
+     */
+    public function testAddBeforeAfterMiddlewareBadMethodCallException()
+    {
+        $app = new Application();
+        $routingServiceProvider = new RoutingServiceProvider();
+        $route = $this->validRoute;
+
+        $middlewareClassName = 'FooMiddleware3';
+        $middlewareMethod = 'foo3';
+
+        //Create a Middleware-class mock
+        /** @var \PHPUnit_Framework_MockObject_MockObject $fooMiddleware */
+        $fooMiddleware = $this->getMockBuilder('none')
+            ->setMockClassName($middlewareClassName)
+            ->getMock();
+
+        $route['before'] = [$middlewareClassName . '::' . $middlewareMethod];
 
         $routingServiceProvider->addRoute($app, $route);
 

--- a/tests/MJanssen/Provider/RoutingServiceProviderTest.php
+++ b/tests/MJanssen/Provider/RoutingServiceProviderTest.php
@@ -262,9 +262,10 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testRoutePattern()
     {
         $routeCollection = $this->getValidRoute();
+        /** @var \Silex\Route $route */
         $route = $routeCollection->getIterator()->current();
 
-        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('/foo', $route->getPath());
     }
 
     /**
@@ -386,6 +387,31 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
         $route['before'] = '';
+        $routingServiceProvider->addRoute($app, $route);
+
+    }
+
+    /**
+     *
+     */
+    public function testAddBeforeAfterMiddlewareByString()
+    {
+        $app = new Application();
+        $routingServiceProvider = new RoutingServiceProvider();
+        $route = $this->validRoute;
+
+        $mwClassName = 'FooMiddleware';
+        $mwMethod = 'foo';
+
+        //Create a Middleware-class mock
+        /** @var \PHPUnit_Framework_MockObject_MockObject $fooMiddleware */
+        $fooMiddleware = $this->getMockBuilder('none')
+            ->setMockClassName($mwClassName)
+            ->setMethods(array($mwMethod))
+            ->getMock();
+
+        $route['before'] = [$mwClassName . '::' . $mwMethod];
+
         $routingServiceProvider->addRoute($app, $route);
 
     }


### PR DESCRIPTION
Two commits:

* The first commit adds the possibility to specify a before/after route middleware class
* The second commit adds the missing HTTP-request methods. Now the methods 'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'purge', 'options', 'trace', 'connect' are supported
* The third commit implements the suggestions from Marcos Janssen
* The fourth commit adds the possibility to add route variable converters