### PR TITLE
Make it so that method can be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require marcojanssen/silex-routing-service-provider
 Each route is required to have the following parameters:
 * pattern (string) 
 * controller (string)
-* method - get, put, post, delete, options, head (array)
+* method - get, put, post, delete, options, head (array|string)
 
 Optionally, you can set a route name (for [named routes](http://silex.sensiolabs.org/doc/usage.html#named-routes)). The key of the $route-array will be used as the route name or you can set it like this:
 
@@ -132,7 +132,7 @@ $routes = array(
         //'name' => 'baz', --> you can omit the route name if a key is set
         'pattern' => '/baz',
         'controller' => 'Baz\Controller\BazController::bazAction',
-        'method' => array('get', 'post', 'put', 'delete', 'options', 'head')
+        'method' => 'get'
     )
 );
 
@@ -228,9 +228,7 @@ return array(
         array(
             'pattern' => '/foo/{id}',
             'controller' => 'Foo\Controllers\FooController::getAction',
-            'method' => array(
-                'get'
-            ),
+            'method' => 'get',
             'assert' => array(
                 'id' => '^[\d]+$'
             ),

--- a/src/MJanssen/Provider/RoutingServiceProvider.php
+++ b/src/MJanssen/Provider/RoutingServiceProvider.php
@@ -76,8 +76,11 @@ class RoutingServiceProvider implements ServiceProviderInterface
      */
     public function addRoute(Application $app, array $route, $name = '')
     {
-        $this->validateRoute($route);
+        if (isset($route['method']) && is_string($route['method'])) {
+            $route['method'] = array($route['method']);
+        }
 
+        $this->validateRoute($route);
 
         if (array_key_exists('name', $route)) {
             $name = $route['name'];

--- a/tests/MJanssen/Provider/RoutingServiceProviderTest.php
+++ b/tests/MJanssen/Provider/RoutingServiceProviderTest.php
@@ -148,9 +148,30 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $routingServiceProvider->addRoute($app, $route);
         $routes = $app['controllers']->flush();
-
         $this->assertCount(1, $routes);
     }
+
+    /**
+     * test if single route with string method can be added
+     */
+    public function testStringMethod()
+    {
+        $app = new Application();
+        $routingServiceProvider = new RoutingServiceProvider();
+
+        $route = array(
+            'name' => 'foo',
+            'pattern' => '/foo',
+            'controller' => 'MJanssen\Controller\FooController::fooAction',
+            'method' => 'get'
+        );
+
+        $routingServiceProvider->addRoute($app, $route);
+        $routes = $app['controllers']->flush();
+        $it = $routes->getIterator();
+        $this->assertEquals('GET', $it['foo']->getMethods()[0]);
+    }
+
 
     /**
      * test if invalid application config is triggerd
@@ -177,7 +198,7 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * test if a method should be an array
+     * test if a method should be a string with valid methods
      * @expectedException InvalidArgumentException
      */
     public function testInvalidMethodType()
@@ -185,12 +206,12 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
         $routingServiceProvider = new RoutingServiceProvider();
         $route = $this->validRoute;
-        $route['method'] = 'get';
+        $route['method'] = 'foo';
         $routingServiceProvider->addRoute($app, $route);
     }
 
     /**
-     * test if a method should be an array
+     * test if a method should be an array with valid methods
      * @expectedException InvalidArgumentException
      */
     public function testInvalidMethodValue()


### PR DESCRIPTION
I think it's cleaner if you only have one method for a route then you can just make it a string rather than a array eg:
```
home.index:
  pattern: /
  method: get
```

rather than
```
home.index:
  pattern: /
  method: ['get']
```